### PR TITLE
fix(chatbot): resolve channel sender AttributeError and fix empty repai command crash

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -24,7 +24,7 @@ async def im_lonely_chat_with_me(event):
         try:
             message = event.text.split(" ", 1)[1]
         except IndexError:
-            return await eod(event, get_string("tban_1"), time=10)
+            return await event.reply(get_string("tban_1"))
     reply_ = await get_chatbot_reply(message=message)
     await event.eor(reply_)
 

--- a/chatbot.py
+++ b/chatbot.py
@@ -94,7 +94,7 @@ async def chat_bot_fn(event, type_):
 @ultroid_bot.on(events.NewMessage(incoming=True))
 async def chatBot_replies(e):
     sender = await e.get_sender()
-    if sender.bot:
+    if not sender or getattr(sender, 'bot', False):
         return
     key = udB.get_key("CHATBOT_USERS") or {}
     if e.text and key.get(e.chat_id) and sender.id in key[e.chat_id]:


### PR DESCRIPTION
## Summary
This PR addresses two critical runtime errors in `chatbot.py` that cause event loop crashes and fill console logs with unnecessary exceptions.

---

## 🐛 Bug Fixes & Changes Made

### 1. Fix `AttributeError` on Channel Messages (`chatBot_replies`)
* **Issue:** When a channel posts a message or comment (e.g., in discussion groups), Telethon returns a `Channel` entity as the sender rather than a `User`. Because `Channel` objects do not possess a `.bot` attribute, calling `if sender.bot:` raises `AttributeError: 'Channel' object has no attribute 'bot'`.
* **Fix:** Safely check the attribute using `getattr(sender, 'bot', False)` and added a check to verify `sender` exists before evaluating.

### 2. Fix `MessageIdInvalidError` / `IndexError` on Empty `.repai`
* **Issue:** Executing `.repai` without a reply target or additional text triggers an `IndexError` when attempting to split the command args. The subsequent `except` block attempted to edit the command message using `eod()`, which threw a `telethon.errors.rpcerrorlist.MessageIdInvalidError` in environments without edit permissions on the original message.
* **Fix:** Replaced the `eod()` helper call with `event.reply()` in the exception handler to safely alert the user without raising RPC errors.

---

## 🧪 Testing
- [x] Tested `.repai` with no arguments, verified the user receives the missing args prompt via reply without crashing.
- [x] Simulated incoming channel messages in a group with `chatBot_replies` active; verified no `AttributeError` is logged.