### PR TITLE
fix(whichsong): update shazamio API call to resolve DeprecationWarning

### DIFF
--- a/whichsong.py
+++ b/whichsong.py
@@ -30,7 +30,7 @@ async def song_recog(event):
     await reply.download_media(path_to_song)
     await xx.edit(get_string("whs_2"))
     try:
-        res = await shazam.recognize_song(path_to_song)
+        res = await shazam.recognize(path_to_song)
     except Exception as e:
         return await eor(xx, str(e), time=10)
     remove(path_to_song)


### PR DESCRIPTION
## Summary
This PR addresses a deprecation warning in the `whichsong.py` plugin[cite: 5] that occurs during audio recognition, ensuring the module remains compatible with newer versions of the `shazamio` library[cite: 5].

---

## 🐛 Bug Fixes & Changes Made
* **Issue:** The `whichsong` plugin utilizes the `recognize_song` method from the `shazamio` package[cite: 5]. This function has been explicitly deprecated by the upstream library, which throws a `DeprecationWarning` into the console and flags it for removal in future updates.
* **Fix:** Replaced `shazam.recognize_song(path_to_song)` with the updated and supported `shazam.recognize(path_to_song)` method[cite: 5].

---

## 🧪 Testing
- [x] Triggered `.whichsong` on an audio file and verified that the `shazamio` engine successfully identifies the track and returns the correct title without logging any deprecation warnings.